### PR TITLE
Add SFT/RL metric validation and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 venv/
 __pycache__/
 test_*.py
+!tests/test_*.py

--- a/examples/blackjack.py
+++ b/examples/blackjack.py
@@ -165,13 +165,23 @@ def main() -> None:
             done = terminated or truncated
             step += 1
 
+        episode_messages = list(agent.current_episode_messages)
+        episode_return = sum(agent.current_episode_rewards)
+        episode_length = step
+
+        train_stats = agent.terminate_episode()
         episode_stats = {
             "episode": episode,
-            "total_return": sum(agent.current_episode_rewards),
-            "message_ct": len(agent.current_episode_messages),
-            "episode_messages": agent.current_episode_messages,
+            "total_return": episode_return,
+            "rl/episode_return": episode_return,
+            "rl/episode_length": episode_length,
+            "message_ct": len(episode_messages),
+            "episode_messages": episode_messages,
         }
-        train_stats = agent.terminate_episode()
+
+        if getattr(agent, "replay_buffer", None) is not None:
+            episode_stats.update(agent.replay_buffer.summary())
+
         episode_stats.update(train_stats)
 
         def convert_for_wandb(value):

--- a/llamagym/sft_trainer.py
+++ b/llamagym/sft_trainer.py
@@ -92,6 +92,7 @@ class SFTTrainer:
 
         total_loss = 0.0
         num_steps = 0
+        skipped_steps = 0
         
         # Calculate total steps for progress bar
         total_sft_steps = self.sft_steps * len(sft_data)
@@ -111,6 +112,7 @@ class SFTTrainer:
                             avg_loss_display = total_loss / num_steps if num_steps > 0 else 0.0
                             pbar.set_postfix(loss=f"{loss:.4f}", avg_loss=f"{avg_loss_display:.4f}")
                         else:
+                            skipped_steps += 1
                             pbar.set_postfix(loss="skip", avg_loss=f"{total_loss/max(1,num_steps):.4f}")
                         pbar.update(1)
         finally:
@@ -120,10 +122,12 @@ class SFTTrainer:
         avg_loss = total_loss / max(1, num_steps)
         print(f"✅ SFT warm-start completed! Avg loss: {avg_loss:.4f}")
         return {
-            "sft_loss": avg_loss,
-            "sft_steps": num_steps,
-            "sft_episodes_used": len(top_episodes),
-            "sft_pairs_used": len(sft_data)
+            "sft/loss": float(avg_loss),
+            "sft/steps": float(num_steps),
+            "sft/skipped_steps": float(skipped_steps),
+            "sft/episodes_used": float(len(top_episodes)),
+            "sft/pairs_used": float(len(sft_data)),
+            "sft/optimizer/lr": float(lrs[0] if lrs else self.sft_lr),
         }
     
     def _sft_step(self, obs_text: str, response_text: str, system_prompt: str, 

--- a/tests/test_sft.py
+++ b/tests/test_sft.py
@@ -1,0 +1,147 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from llamagym.replay import ReplayBuffer
+from llamagym.sft_trainer import SFTTrainer
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self.pad_token_id = 0
+        self.eos_token_id = 1
+        self.eos_token = "<eos>"
+        self.truncation_side = "right"
+        self.padding_side = "left"
+        self.model_max_length = 256
+        self.name_or_path = "dummy"
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        parts = [f"{m['role']}::{m['content']}" for m in messages]
+        text = "\n".join(parts)
+        if add_generation_prompt:
+            text += "\nassistant::"
+        return text
+
+    def __call__(self, text, return_tensors="pt", truncation=False, max_length=None):
+        if isinstance(text, (list, tuple)):
+            text = "".join(text)
+        encoded = [(ord(ch) % 50) + 2 for ch in text]
+        if not encoded:
+            encoded = [0]
+        input_ids = torch.tensor(encoded, dtype=torch.long).unsqueeze(0)
+        if max_length is not None and input_ids.size(1) > max_length:
+            input_ids = input_ids[:, -max_length:]
+        attention_mask = torch.ones_like(input_ids)
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def decode(self, ids, skip_special_tokens=True):
+        if isinstance(ids, torch.Tensor):
+            ids = ids.tolist()
+        return "".join(chr((i - 2) % 50) for i in ids)
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, vocab_size: int = 64, hidden_size: int = 8):
+        super().__init__()
+        self.embed = torch.nn.Embedding(256, hidden_size)
+        self.lm_head = torch.nn.Linear(hidden_size, vocab_size)
+        self.v_head = torch.nn.Linear(hidden_size, 1)
+        self.config = SimpleNamespace(use_cache=True)
+
+    def forward(self, input_ids, attention_mask=None):
+        hidden = self.embed(input_ids)
+        logits = self.lm_head(hidden)
+        return SimpleNamespace(logits=logits)
+
+
+class DummyPbar:
+    def __init__(self):
+        self.total_updates = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def update(self, n):
+        self.total_updates += n
+
+    def set_postfix(self, **kwargs):
+        pass
+
+
+class ReplayBufferSummaryTest(unittest.TestCase):
+    def test_summary_contains_expected_metrics(self):
+        buffer = ReplayBuffer(seed=0)
+        buffer.add_episode([
+            {"obs_text": "obs1", "response_text": "resp1", "reward": 0.6, "total_return": 1.0},
+            {"obs_text": "obs2", "response_text": "resp2", "reward": 0.4, "total_return": 1.0},
+        ])
+        buffer.add_episode([
+            {"obs_text": "obs3", "response_text": "resp3", "reward": -1.0, "total_return": -1.0},
+        ])
+
+        summary = buffer.summary()
+        self.assertEqual(summary["replay/episodes"], 2.0)
+        self.assertEqual(summary["replay/steps"], 3.0)
+        self.assertAlmostEqual(summary["replay/return/mean"], 0.0)
+        self.assertAlmostEqual(summary["replay/return/std"], 1.0)
+        self.assertEqual(summary["replay/pair_count"], 3.0)
+        self.assertEqual(summary["replay/pair_unique"], 3.0)
+        self.assertAlmostEqual(summary["replay/success_rate"], 0.5)
+
+
+class SFTTrainerMetricsTest(unittest.TestCase):
+    def test_warmstart_metrics_are_prefixed(self):
+        buffer = ReplayBuffer(seed=0)
+        buffer.add_episode([
+            {"obs_text": "first", "response_text": "resp_a", "reward": 1.0, "total_return": 2.0},
+            {"obs_text": "second", "response_text": "resp_b", "reward": 1.0, "total_return": 2.0},
+        ])
+        buffer.add_episode([
+            {"obs_text": "third", "response_text": "resp_c", "reward": 0.2, "total_return": 1.0},
+        ])
+
+        model = DummyModel()
+        tokenizer = DummyTokenizer()
+        trainer = SFTTrainer(model, tokenizer, ppo_trainer=mock.Mock(), replay_buffer=buffer, sft_steps=2, topk_p=0.5)
+
+        expected_pairs = len(buffer.get_sft_data(buffer.sample_topk(0.5), max_pairs=128, dedup=True))
+
+        with mock.patch.object(SFTTrainer, "_sft_step", return_value=0.25) as step_mock, \
+                mock.patch("llamagym.sft_trainer.tqdm", return_value=DummyPbar()):
+            stats = trainer.run_sft_warmstart(lambda: "system prompt")
+
+        self.assertIn("sft/loss", stats)
+        self.assertAlmostEqual(stats["sft/loss"], 0.25)
+        self.assertEqual(int(stats["sft/steps"]), expected_pairs * trainer.sft_steps)
+        self.assertEqual(stats["sft/skipped_steps"], 0.0)
+        self.assertGreaterEqual(stats["sft/episodes_used"], 1.0)
+        self.assertEqual(stats["sft/pairs_used"], float(expected_pairs))
+        self.assertEqual(stats["sft/optimizer/lr"], trainer.sft_lr)
+        self.assertEqual(step_mock.call_count, expected_pairs * trainer.sft_steps)
+
+
+class WarmstartDataTest(unittest.TestCase):
+    def test_demo_blackjack_warmstart_data(self):
+        data_path = Path(__file__).resolve().parents[1] / "demo_blackjack.jsonl"
+        buffer = ReplayBuffer()
+        count = buffer.ingest_jsonl(str(data_path))
+
+        self.assertGreater(count, 0)
+        summary = buffer.summary()
+        self.assertEqual(summary["replay/episodes"], float(count))
+        self.assertEqual(summary["replay/pair_count"], float(count))
+        self.assertGreaterEqual(summary["replay/pair_unique"], 1.0)
+
+        for episode in list(buffer.episodes)[:5]:
+            self.assertTrue(episode[0]["response_text"].startswith("{"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add replay buffer summary metrics and expose combined RL + SFT logging from the agent and blackjack demo
- extend the SFT trainer warm-start routine to report prefixed metrics suitable for W&B dashboards
- add lightweight unit tests that exercise replay summarization, SFT metric reporting, and demo warm-start data ingestion

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68c9b3461de8832a831a5ab9ea66a116